### PR TITLE
Bytea optimization

### DIFF
--- a/parquet_impl.cpp
+++ b/parquet_impl.cpp
@@ -762,13 +762,6 @@ read_primitive_type(arrow::Array *array,
             break;
         }
         case arrow::Type::STRING:
-        {
-            arrow::StringArray *stringarray = (arrow::StringArray *) array;
-            std::string value = stringarray->GetString(i);
-
-            res = CStringGetTextDatum(value.c_str());
-            break;
-        }
         case arrow::Type::BINARY:
         {
             arrow::BinaryArray *binarray = (arrow::BinaryArray *) array;

--- a/parquet_impl.cpp
+++ b/parquet_impl.cpp
@@ -772,10 +772,12 @@ read_primitive_type(arrow::Array *array,
         case arrow::Type::BINARY:
         {
             arrow::BinaryArray *binarray = (arrow::BinaryArray *) array;
-            std::string value = binarray->GetString(i);
+
+            int32_t vallen = 0;
+            const char *value = reinterpret_cast<const char*>(binarray->GetValue(i, &vallen));
 
             /* Build bytea */
-            bytea *b = cstring_to_text_with_len(value.data(), value.size());
+            bytea *b = cstring_to_text_with_len(value, vallen);
 
             res = PointerGetDatum(b);
             break;


### PR DESCRIPTION
Bypassing unnecessary allocations and smart pointer juggling. Roughly gives us another 5-8% when strings/bytea are involved